### PR TITLE
Add prepare script so it auto-builds when using vim-plug

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "clean": "rm -rf lib/",
     "build": "webpack",
     "lint": "eslint .",
-    "prepack": "npm run clean && npm run build"
+    "prepack": "npm run clean && npm run build",
+    "prepare": "npx npm-run-all clean build"
   },
   "repository": "github:amiralies/coc-flow",
   "contributes": {


### PR DESCRIPTION
Other coc extensions have this script so the extension auto installs when adding plugins through vim-plug by using this command on your config (as recommended by coc's documentation):
```
Plug 'amiralies/coc-flow', {'do': 'yarn install --frozen-lockfile'}
```
Added that same script here so it works out of the box as well.

Btw, thanks for the extension!